### PR TITLE
ZKVM-1372: Automatically link in risc0-bigint2

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -47,6 +47,7 @@ glob = "0.3"
 [dependencies]
 zeroize = { version = "^1.1", features = ["zeroize_derive"] }
 serde = { version = "1.0.152", optional = true }
+risc0-bigint2 = { version = "^1.4.2", default-features = false, features = ["unstable"] }
 
 [target.'cfg(not(any(target_arch="wasm32", target_os="none", target_os="unknown", target_os="uefi")))'.dependencies]
 threadpool = "^1.8.1"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -10,6 +10,9 @@
 
 extern crate alloc;
 
+#[allow(unused_imports)]
+use risc0_bigint2::field as _;
+
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -780,9 +783,7 @@ macro_rules! sig_variant_impl {
         // of the secret key material.
         impl<'a> From<&'a SecretKey> for &'a blst_scalar {
             fn from(sk: &'a SecretKey) -> Self {
-                unsafe {
-                    transmute::<&SecretKey, Self>(sk)
-                }
+                unsafe { transmute::<&SecretKey, Self>(sk) }
             }
         }
 
@@ -1717,8 +1718,7 @@ macro_rules! sig_variant_impl {
 
             fn add(&self) -> Self::Output {
                 Self::Output {
-                    point: unsafe { transmute::<&[_], &[$pk_aff]>(self) }
-                        .add(),
+                    point: unsafe { transmute::<&[_], &[$pk_aff]>(self) }.add(),
                 }
             }
 


### PR DESCRIPTION
This PR adds risc0-bigint2 as a dependency of the blst rust wrapper. This fixes the issue where program compilation fails at linking because certain extern symbols exported from risc0-bigint2 that are used in the blst C++ code are not found. 

This makes it so that downstream users of this library do not need to add risc0-bigint2 as a dependency.