### PR TITLE
ZKVM-1381: fix: Remove acceleration of `ct_inverse_mod_n`

### DIFF
--- a/src/no_asm.h
+++ b/src/no_asm.h
@@ -1139,16 +1139,6 @@ static limb_t smul_2n(limb_t ret[], const limb_t u[], limb_t f,
     return hi;
 }
 
-#if defined(__ZKVM__)
-inline void ct_inverse_mod_256(vec512 ret, const vec256 inp,
-                               const vec256 mod, const vec256 modx) { //untested
-    r0bigint_modinv_256(inp, mod, ret);
-}
-inline void ct_inverse_mod_384(vec768 ret, const vec384 inp,
-                               const vec384 mod, const vec384 modx) {
-    r0bigint_modinv_384(inp, mod, ret);
-}
-#else
 static void ct_inverse_mod_n(limb_t ret[], const limb_t inp[],
                              const limb_t mod[], const limb_t modx[], size_t n)
 {
@@ -1200,7 +1190,6 @@ inline void ct_inverse_mod_##bits(vec##bits2 ret, const vec##bits inp, \
 
 CT_INVERSE_MOD_IMPL(256, 512)
 CT_INVERSE_MOD_IMPL(384, 768)
-#endif
 
 /*
  * Copy of inner_loop_n above, but with |L| updates.


### PR DESCRIPTION
This fixes the c-kzg verification flow.